### PR TITLE
Add virtual MCU example with input pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Virtual_input
+# Virtual Input Pins
+
+This repository contains a small Python module that emulates a minimal
+microcontroller with eight virtual input pins.  The pins are named
+`pin1` through `pin8` and are exposed using the prefix `ams` so they
+can be referenced as `ams:pin1` ... `ams:pin8` in Klipper
+configurations.
+
+The code does **not** implement the full Klipper MCU protocol; it is a
+lightweight example that can be extended or adapted for integration
+with Klipper's host-side code.
+
+## Usage
+
+Run `virtual_mcu.py` directly to create the virtual MCU instance::
+
+    python3 virtual_mcu.py
+
+The script will print the available pins.  Pins can be manipulated by
+calling the `set_pin` and `read_pin` methods on the `VirtualMCU`
+instance from Python code.
+
+This is intended as a starting point for creating a more complete
+virtual MCU that Klipper can communicate with.
+

--- a/virtual_mcu.py
+++ b/virtual_mcu.py
@@ -1,0 +1,39 @@
+class VirtualPin:
+    """A simple digital input pin."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.state = 0
+
+    def read(self) -> int:
+        return self.state
+
+    def set_state(self, value: bool) -> None:
+        self.state = 1 if value else 0
+
+
+class VirtualMCU:
+    """A minimal MCU emulator exposing 8 input pins."""
+
+    def __init__(self, prefix: str = "ams"):
+        self.prefix = prefix
+        self.pins = {f"pin{i}": VirtualPin(f"{prefix}:pin{i}") for i in range(1, 9)}
+
+    def read_pin(self, pin: str) -> int:
+        return self.pins[pin].read()
+
+    def set_pin(self, pin: str, value: bool) -> None:
+        self.pins[pin].set_state(value)
+
+    def list_pins(self):
+        return list(self.pins.keys())
+
+
+if __name__ == "__main__":
+    mcu = VirtualMCU()
+    print("Virtual MCU initialized with pins:", ", ".join(mcu.list_pins()))
+    print(
+        "Use mcu.set_pin(name, value) to change pin state "
+        "and mcu.read_pin(name) to read it."
+    )
+


### PR DESCRIPTION
## Summary
- add a README describing the virtual MCU example
- implement `virtual_mcu.py` which creates eight virtual input pins

## Testing
- `python3 -m py_compile virtual_mcu.py`
- `python3 virtual_mcu.py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688252c1181483268b4409081e09af9c