### PR TITLE
Fix module import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# Virtual_input
+# Virtual Input Pins
+
+This repository contains Python code that emulates a minimal
+microcontroller with eight input pins.  These pins are named `pin1`
+through `pin8` and are presented under the prefix `ams` so they can be
+referenced as `ams:pin1` ... `ams:pin8` in Klipper configurations.
+
+The example does **not** implement the full Klipper MCU protocol.  It is
+a lightweight demonstration that can be expanded for integration with
+Klipper's host-side code.
+
+## Usage
+
+### Simple Python usage
+
+Run `virtual_mcu.py` directly to create a `VirtualMCU` instance:
+
+```bash
+python3 virtual_mcu.py
+```
+
+The script will print the available pins.  Pins can be manipulated by
+calling the `set_pin` and `read_pin` methods from Python code.
+
+### Loading via printer.cfg
+
+The module `input_pins.py` provides a small example of how a Klipper
+plugin might load the virtual MCU when the configuration contains an
+`[input_pins]` section.  In your `printer.cfg`, add::
+
+    [input_pins]
+
+Then call `input_pins.load_config('printer.cfg')` from Python (or from
+Klipper's module loader) and the virtual MCU will be created
+automatically.
+
+Copy both `input_pins.py` and `virtual_mcu.py` into Klipper's
+`klippy/extras/` directory so the relative import works when the module
+is loaded as `extras.input_pins`.
+
+This setup shows how a configuration section can trigger loading custom
+code, but a real deployment would need additional work to fully emulate
+the MCU protocol.

--- a/example_printer.cfg
+++ b/example_printer.cfg
@@ -1,0 +1,2 @@
+[input_pins]
+# add options here if desired

--- a/input_pins.py
+++ b/input_pins.py
@@ -1,0 +1,47 @@
+"""Klipper plugin to create eight virtual input pins.
+
+This module checks for an [input_pins] section in the given configuration
+file and, if present, loads VirtualMCU to provide ams:pin1-ams:pin8.
+
+This is a simplified example intended to illustrate how one might hook a
+custom module into Klipper's configuration system. It does not implement
+the full Klipper MCU protocol.
+"""
+
+import configparser
+from typing import Optional
+
+# Import VirtualMCU from the same package when running as a Klipper
+# extras module.  Fallback to a direct import so the file can still be
+# executed or compiled standalone during development.
+try:
+    from .virtual_mcu import VirtualMCU
+except ImportError:  # pragma: no cover - fallback when not in package
+    from virtual_mcu import VirtualMCU
+
+
+class InputPins:
+    """Manage a VirtualMCU when [input_pins] is present."""
+
+    def __init__(self) -> None:
+        self.mcu: Optional[VirtualMCU] = None
+
+    def load_from_file(self, cfg_path: str) -> None:
+        """Load configuration and initialize VirtualMCU if needed."""
+        parser = configparser.ConfigParser()
+        parser.read(cfg_path)
+        if "input_pins" in parser:
+            self.mcu = VirtualMCU()
+            print(
+                "InputPins: Virtual MCU loaded with pins:",
+                ", ".join(self.mcu.list_pins()),
+            )
+        else:
+            print("InputPins: [input_pins] not defined; module not loaded")
+
+
+def load_config(cfg_path: str) -> InputPins:
+    """Convenience function mirroring Klipper's load_config interface."""
+    ip = InputPins()
+    ip.load_from_file(cfg_path)
+    return ip

--- a/virtual_mcu.py
+++ b/virtual_mcu.py
@@ -1,0 +1,39 @@
+class VirtualPin:
+    """A simple digital input pin."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.state = 0
+
+    def read(self) -> int:
+        return self.state
+
+    def set_state(self, value: bool) -> None:
+        self.state = 1 if value else 0
+
+
+class VirtualMCU:
+    """A minimal MCU emulator exposing 8 input pins."""
+
+    def __init__(self, prefix: str = "ams"):
+        self.prefix = prefix
+        self.pins = {f"pin{i}": VirtualPin(f"{prefix}:pin{i}") for i in range(1, 9)}
+
+    def read_pin(self, pin: str) -> int:
+        return self.pins[pin].read()
+
+    def set_pin(self, pin: str, value: bool) -> None:
+        self.pins[pin].set_state(value)
+
+    def list_pins(self):
+        return list(self.pins.keys())
+
+
+if __name__ == "__main__":
+    mcu = VirtualMCU()
+    print("Virtual MCU initialized with pins:", ", ".join(mcu.list_pins()))
+    print(
+        "Use mcu.set_pin(name, value) to change pin state "
+        "and mcu.read_pin(name) to read it."
+    )
+


### PR DESCRIPTION
## Summary
- fix `input_pins` import so it works from Klipper's `extras` package
- document copying plugin files to `klippy/extras/`

## Testing
- `python3 -m py_compile virtual_mcu.py input_pins.py`
- `python3 - <<'EOF'
from input_pins import load_config
load_config('example_printer.cfg')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688252c1181483268b4409081e09af9c