### PR TITLE
Add ams virtual input pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# Virtual_input
+# Virtual Input Pins
+
+This repository contains Python code that emulates a minimal
+microcontroller with eight input pins.  These pins are named `pin1`
+through `pin8` and are presented under the prefix `ams` so they can be
+referenced as `ams:pin1` ... `ams:pin8` in Klipper configurations.
+The intent is that Klipper treats the pins as coming from a real
+microcontroller called `ams`.
+
+The example does **not** implement the full Klipper MCU protocol.  It is
+a lightweight demonstration that can be expanded for integration with
+Klipper's host-side code.
+
+## Usage
+
+### Simple Python usage
+
+Run `virtual_mcu.py` directly to create a `VirtualMCU` instance:
+
+```bash
+python3 virtual_mcu.py
+```
+
+The script will print the available pins.  Pins can be manipulated by
+calling the `set_pin` and `read_pin` methods from Python code.
+For example the output will look like::
+
+    Virtual MCU initialized with pins: ams:pin1, ams:pin2, ...
+
+### Loading via printer.cfg
+
+The module `input_pins.py` provides a small example of how a Klipper
+plugin might load the virtual MCU when the configuration contains an
+`[input_pins]` section.  In your `printer.cfg`, add::
+
+    [input_pins]
+    prefix: ams
+
+Then call `input_pins.load_config_file('printer.cfg')` from Python (or let
+Klipper load the module) and the virtual MCU will be created
+automatically.  The optional `prefix` setting controls the name used in
+pin references (default `ams`).  When loaded by Klipper, the module
+registers the prefix so that other sections may refer to pins such as
+`ams:pin1` without additional setup.
+
+Make sure the `[input_pins]` section appears *before* any other
+sections that reference these pins so that the chip is registered when
+Klipper parses the rest of the configuration.
+
+Once loaded, you can reference the pins in other sections of
+`printer.cfg` using the `ams:` prefix, for example::
+
+    [filament_switch_sensor my_filament]
+    switch_pin: ams:pin1
+
+Copy both `input_pins.py` and `virtual_mcu.py` into Klipper's
+`klippy/extras/` directory so the relative import works when the module
+is loaded as `extras.input_pins`.
+
+This setup shows how a configuration section can trigger loading custom
+code, but a real deployment would need additional work to fully emulate
+the MCU protocol.

--- a/example_printer.cfg
+++ b/example_printer.cfg
@@ -1,0 +1,2 @@
+[input_pins]
+# add options here if desired

--- a/input_pins.py
+++ b/input_pins.py
@@ -1,0 +1,69 @@
+"""Klipper plugin to create eight virtual input pins.
+
+This module checks for an [input_pins] section in the given configuration
+file and, if present, loads VirtualMCU to provide ams:pin1-ams:pin8.
+
+This is a simplified example intended to illustrate how one might hook a
+custom module into Klipper's configuration system. It does not implement
+the full Klipper MCU protocol.
+"""
+
+import configparser
+from typing import Optional
+
+try:  # When loaded by Klipper
+    from .. import pins as klipper_pins  # type: ignore
+except Exception:  # pragma: no cover - standalone use
+    klipper_pins = None
+
+# Import VirtualMCU from the same package when running as a Klipper
+# extras module.  Fallback to a direct import so the file can still be
+# executed or compiled standalone during development.
+try:
+    from .virtual_mcu import VirtualMCU
+except ImportError:  # pragma: no cover - fallback when not in package
+    from virtual_mcu import VirtualMCU
+
+
+class InputPins:
+    """Manage a VirtualMCU when [input_pins] is present."""
+
+    def __init__(self) -> None:
+        self.mcu: Optional[VirtualMCU] = None
+
+    def load_from_file(self, cfg_path: str) -> None:
+        """Load configuration and initialize VirtualMCU if needed."""
+        parser = configparser.ConfigParser()
+        parser.read(cfg_path)
+        if "input_pins" in parser:
+            prefix = parser["input_pins"].get("prefix", "ams")
+            self.mcu = VirtualMCU(prefix=prefix)
+            self.mcu.register_chip()
+            print(
+                "InputPins: Virtual MCU loaded with pins:",
+                ", ".join(self.mcu.list_pins()),
+            )
+        else:
+            print("InputPins: [input_pins] not defined; module not loaded")
+
+
+def load_config_file(cfg_path: str) -> InputPins:
+    """Convenience wrapper for standalone testing."""
+    ip = InputPins()
+    ip.load_from_file(cfg_path)
+    return ip
+
+
+def load_config(config):  # pragma: no cover - used by Klipper
+    """Entry point used by Klipper when [input_pins] is present."""
+    prefix = config.get('prefix', 'ams')
+    ip = InputPins()
+    ip.mcu = VirtualMCU(prefix=prefix)
+    ip.mcu.register_chip()
+    config.get_printer().add_object('virtual_mcu', ip.mcu)
+    return ip
+
+
+# For backward compatibility with earlier revisions that used
+# ``load_config_prefix``.
+load_config_prefix = load_config

--- a/virtual_mcu.py
+++ b/virtual_mcu.py
@@ -1,0 +1,104 @@
+"""Minimal virtual MCU used for Klipper testing.
+
+This module provides a very small mock MCU that exposes eight pins.  It is
+not a full implementation of Klipper's MCU protocol, but it implements enough
+of the pin interface for Klipper to treat the pins as valid inputs.
+"""
+
+from dataclasses import dataclass
+
+try:  # Klipper provides a ``pins`` module when running as an extra
+    from .. import pins as klipper_pins  # type: ignore
+except Exception:  # pragma: no cover - running standalone
+    klipper_pins = None
+
+
+@dataclass
+class VirtualPin:
+    """A simple digital pin with configurable mode and state."""
+
+    name: str
+    mode: str = "input"
+    state: int = 0
+
+    def configure(self, mode: str) -> None:
+        self.mode = mode
+
+    def read(self) -> int:
+        return self.state
+
+    def set_state(self, value: bool) -> None:
+        self.state = 1 if value else 0
+
+
+class VirtualMCU:
+    """A minimal MCU emulator exposing 8 input pins."""
+
+    def __init__(self, prefix: str = "ams"):
+        self.prefix = prefix
+        self.pins = {
+            f"pin{i}": VirtualPin(f"{prefix}:pin{i}") for i in range(1, 9)
+        }
+
+    def read_pin(self, pin: str) -> int:
+        return self.pins[pin].read()
+
+    def set_pin(self, pin: str, value: bool) -> None:
+        self.pins[pin].set_state(value)
+
+    def configure_pin(self, pin: str, mode: str) -> None:
+        self.pins[pin].configure(mode)
+
+    def list_pins(self) -> list[str]:
+        """Return pin names including the prefix."""
+        return [pin.name for pin in self.pins.values()]
+
+    def register_chip(self) -> None:
+        """Register this MCU with Klipper's pin subsystem if available."""
+        if klipper_pins is not None:
+            klipper_pins.register_chip(self.prefix, lambda config=None: VirtualPinChip(self))
+
+
+class VirtualPinRef:
+    """Adapter used when Klipper requests a pin."""
+
+    def __init__(self, vpin: VirtualPin) -> None:
+        self.vpin = vpin
+
+    def setup_input(self, pull_up: bool = False, invert: bool = False) -> None:
+        self.vpin.configure("input")
+
+    def setup_output(self, value: int) -> None:
+        self.vpin.configure("output")
+        self.vpin.set_state(bool(value))
+
+    def read(self) -> int:
+        return self.vpin.read()
+
+    def get_mcu(self):  # pragma: no cover - required by Klipper API
+        return None
+
+
+class VirtualPinChip:
+    """Pin chip registering pins under a prefix."""
+
+    def __init__(self, mcu: VirtualMCU) -> None:
+        self._mcu = mcu
+
+    def setup_pin(self, pin: str) -> VirtualPinRef:
+        try:
+            vpin = self._mcu.pins[pin]
+        except KeyError as exc:
+            raise ValueError(f"Invalid virtual pin '{pin}'") from exc
+        return VirtualPinRef(vpin)
+
+
+if __name__ == "__main__":
+    mcu = VirtualMCU()
+    mcu.register_chip()
+    print("Virtual MCU initialized with pins:", ", ".join(mcu.list_pins()))
+    print(
+        "Use mcu.set_pin(name, value) to change pin state "
+        "and mcu.read_pin(name) to read it."
+    )
+


### PR DESCRIPTION
## Summary
- implement configurable prefix for virtual pins
- expand README with usage example and note about `ams:pin1`
- allow prefix setting when loading config in `input_pins`
- track pin mode in `VirtualMCU`
- clarify list_pins output
- register virtual pin chip with Klipper so `ams:` pins resolve
- add `load_config` entry point and document config ordering

## Testing
- `python3 -m py_compile virtual_mcu.py input_pins.py`
- `python3 - <<'EOF'
from input_pins import load_config_file
ip = load_config_file('example_printer.cfg')
print('pins:', ip.mcu.list_pins() if ip.mcu else None)
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688252c1181483268b4409081e09af9c